### PR TITLE
Use the right argument name in init

### DIFF
--- a/room_access_rules/__init__.py
+++ b/room_access_rules/__init__.py
@@ -98,10 +98,10 @@ class RoomAccessRules(object):
     def __init__(
         self,
         config: RoomAccessRulesConfig,
-        module_api: ModuleApi,
+        api: ModuleApi,
     ):
         self.config = config
-        self.module_api = module_api
+        self.module_api = api
 
         self.module_api.register_third_party_rules_callbacks(
             check_event_allowed=self.check_event_allowed,


### PR DESCRIPTION
Turns out Synapse instantiates modules with the keyword argument 'api', see https://github.com/matrix-org/synapse/pull/13060